### PR TITLE
Verificação de status da API ReqRes

### DIFF
--- a/Cópia_de_Teste_01_.ipynb
+++ b/Cópia_de_Teste_01_.ipynb
@@ -1,0 +1,101 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "rtElMOXWwYfX",
+        "outputId": "f39887ff-e4f0-4532-bfc5-69622a0b8aa1"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (2.32.3)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests) (3.4.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests) (2.4.0)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests) (2025.4.26)\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install requests"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import unittest\n",
+        "import requests\n",
+        "\n",
+        "class TestAPI(unittest.TestCase):\n",
+        "    def test_status_code(self):\n",
+        "        \"\"\"Verifica se a API retorna status 200\"\"\"\n",
+        "        response = requests.get(\"https://reqres.in/api/users\")\n",
+        "        self.assertEqual(response.status_code, 200)\n",
+        "\n",
+        "# Rodar os testes no Colab\n",
+        "unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(TestAPI))\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RQsOccETymdb",
+        "outputId": "5d7db54b-1770-450b-80fc-bc1ed2b56b29"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "F\n",
+            "======================================================================\n",
+            "FAIL: test_status_code (__main__.TestAPI.test_status_code)\n",
+            "Verifica se a API retorna status 200\n",
+            "----------------------------------------------------------------------\n",
+            "Traceback (most recent call last):\n",
+            "  File \"<ipython-input-5-7ca76da0cba2>\", line 8, in test_status_code\n",
+            "    self.assertEqual(response.status_code, 200)\n",
+            "AssertionError: 401 != 200\n",
+            "\n",
+            "----------------------------------------------------------------------\n",
+            "Ran 1 test in 0.364s\n",
+            "\n",
+            "FAILED (failures=1)\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<unittest.runner.TextTestResult run=1 errors=0 failures=1>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Biblioteca: Requests  
Objetivo: Verificar se o endpoint retorna status HTTP 200  
Resultado esperado: Teste passa com sucesso se o status for 200  
Arquivo: https://colab.research.google.com/drive/1zm5Ab1HEiNNyRDmrwsJiauEu-lpG7FnY?usp=sharing